### PR TITLE
Add a prompt for missing macOS jdk on install

### DIFF
--- a/chrome/install.js
+++ b/chrome/install.js
@@ -74,6 +74,12 @@ function onLoad() {
 				if(success) wizard.advance();
 			}
 		});
+	} else {
+		checkMacJDK().then(function(success) {
+			if (!success) {
+				wizard.getPageById("intro").next = "jdk-required";
+			}
+		});
 	}
 }
 
@@ -114,6 +120,16 @@ function checkJavaCommon(callback) {
 		});
 	});
 }
+
+var checkMacJDK = Zotero.Promise.coroutine(function* () {
+	var success = false;
+	try {
+		success = yield Zotero.Utilities.Internal.exec('/bin/bash/', ['-c', '/usr/libexec/java_home | grep -e "jdk"']);
+	} catch (e) {
+		Zotero.logError(e);
+	}
+	return success;
+});
 
 function checkJavaCommonPkg(pkgMain, pkgRequired, callback) {
 	// check for openoffice.org-writer with openoffice.org-java-common available but not installed

--- a/chrome/install.xul
+++ b/chrome/install.xul
@@ -5,7 +5,7 @@
 <!DOCTYPE window SYSTEM "chrome://zotero/locale/zotero.dtd">
 
 <wizard xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-	title="Zotero LibreOffice Integration Installation" width="600"
+	title="The Zotero LibreOffice Plugin Installation" width="600"
 	height="450" id="installer" onwizardcancel="return wizardCancelled();"
 	onwizardback="wizardBack(); return false;">
 	
@@ -15,11 +15,11 @@
 	<wizardpage pageid="intro" label="Introduction" onpageshow="introPageShown()"
 	next="openoffice-installations">
 		<description>
-			Zotero LibreOffice Integration makes it easy to insert Zotero
+			The Zotero LibreOffice Plugin makes it easy to insert Zotero
 			citations and bibliographies into these popular word processors. 
 		</description>
 		<description>
-			This wizard will install Zotero LibreOffice Integration for all
+			This wizard will install the Zotero LibreOffice Plugin for all
 			applicable word processors on this computer. The extension can be reinstalled later from
 			the Cite pane in the Zotero preferences.
 		</description>
@@ -33,7 +33,7 @@
 		</vbox>
 		<vbox id="java-common-required" hidden="true" flex="1">
 			<description>
-				Zotero LibreOffice Integration requires following packages:
+				The Zotero LibreOffice Plugin requires following packages:
 			</description>
 			<description id="java-common-packages" style="margin-left:0.5in"></description>
 			<description>
@@ -51,7 +51,7 @@
 		</vbox>
 		<description id="java-common-install-error" flex="1" hidden="true">
 			An error occurred installing required packages. While you can attempt to
-			install Zotero LibreOffice Integration anyway, it is unlikely to work.
+			install the Zotero LibreOffice Plugin anyway, it is unlikely to work.
 			Click Cancel to abort the installation process.
 		</description>
 	</wizardpage>
@@ -60,7 +60,7 @@
 	label="Install Required Components"
 	next="openoffice-installations">
 		<description>
-			Zotero LibreOffice Integration requires the Java 
+			The Zotero LibreOffice Plugin requires the Java
 			Runtime Environment. Visit <label class="zotero-text-link" href="http://java.com/inc/BrowserRedirect1.jsp">Java.com</label>
 			to download it.
 		</description>
@@ -70,7 +70,7 @@
 	label="Install Required Components"
 	next="openoffice-installations">
 		<description>
-			Zotero LibreOffice Integration on MacOS requires the Java 
+			The Zotero LibreOffice Plugin on macOS requires the Java
 			Development Kit. Visit <label class="zotero-text-link" href="https://www.zotero.org/support/word_processor_plugin_troubleshooting#libreoffice_5_on_macos_1011no_response_from_plugin">Zotero wiki</label>
 			for more information.
 		</description>
@@ -85,7 +85,7 @@
 			directory not shown on the list below.
 		</description>
 		<description>
-			To open the directory containing the LibreOffice extension for manual installation
+			To open the directory containing the LibreOffice Plugin for manual installation
 			from within LibreOffice, click "Manual Installation."
 		</description>
 		<listbox height="150" id="installations-listbox" oncommand="openofficeInstallationsListboxSelectionChanged()"/>
@@ -98,7 +98,7 @@
 	<wizardpage pageid="installing" label="Installing..."
 	onpageshow="installingPageShown()" next="installation-complete">
 		<vbox id="installation-progress" flex="1">
-			<label>Installing Zotero LibreOffice Integration...</label>
+			<label>Installing the Zotero LibreOffice Plugin...</label>
 			<progressmeter id="progress-indicator" mode="undetermined"/>
 		</vbox>
 	</wizardpage>
@@ -106,14 +106,14 @@
 	<wizardpage pageid="installation-complete"
 	label="Installation Complete">
 		<description id="installation-successful">
-			Zotero LibreOffice Integration was installed successfully. 
+			The Zotero LibreOffice Plugin was installed successfully.
 			Depending on the way LibreOffice is configured, it may be
 			necessary to restart your computer for changes to take effect.
 		</description>
 		<vbox id="installation-manual" hidden="true" flex="1">
 			<description>
 				You have elected to install the Zotero LibreOffice
-				Integration extension manually. The directory containing the extension should now
+				Plugin manually. The directory containing the extension should now
 				be open. In case it isn't, the full path to the extension is:
 			</description>
 			<description id="installation-manual-path"/>
@@ -124,7 +124,7 @@
 		</vbox>
 		<vbox id="installation-error" hidden="true" flex="1">
 			<description>
-				An error occurred installing Zotero LibreOffice Integration.
+				An error occurred during the installation of the Zotero LibreOffice Plugin.
 			</description>
 			<description>
 				Click the "Previous" button and verify that the application path is correct. If you

--- a/chrome/install.xul
+++ b/chrome/install.xul
@@ -66,6 +66,16 @@
 		</description>
 	</wizardpage>
 	
+    <wizardpage pageid="jdk-required" onpageshow="jreRequiredPageShown()"
+	label="Install Required Components"
+	next="openoffice-installations">
+		<description>
+			Zotero LibreOffice Integration on MacOS requires the Java 
+			Development Kit. Visit <label class="zotero-text-link" href="https://www.zotero.org/support/word_processor_plugin_troubleshooting#libreoffice_5_on_macos_1011no_response_from_plugin">Zotero wiki</label>
+			for more information.
+		</description>
+	</wizardpage>
+	
 	<wizardpage pageid="openoffice-installations" extra1="Add Directory..."
 	extra2="Manual Installation" label="Select LibreOffice unopkg executable"
 	next="installing" onpageshow="openofficeInstallationsPageShown()">


### PR DESCRIPTION
Closes #27

LibreOffice plugin has an installation wizard. I've added a page which tells the user to get JDK if it's not detected. JDK checking is done using `/usr/bin/java_home` as described [in this SO post](https://stackoverflow.com/questions/18144660/what-is-path-of-jdk-on-mac)

The instructions I linked to are not for a fresh plugin install (and slightly misleading), but I cannot edit [Word Processor Plugin Installation](https://www.zotero.org/support/word_processor_plugin_installation) page on the wiki, where the instructions should actually go.