### PR TITLE
Show zotero addon in LibreOffice NotebookBar

### DIFF
--- a/build/oxt/Addons.xcu
+++ b/build/oxt/Addons.xcu
@@ -1,7 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <oor:component-data xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" oor:name="Addons" oor:package="org.openoffice.Office">
 	<node oor:name="AddonUI">
-
+		<node oor:name="OfficeNotebookBar">
+			<node oor:name="Zotero.OfficeToolBar" oor:op="replace">
+				<node oor:name="m1" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>service:org.zotero.integration.ooo.ZoteroOpenOfficeIntegration?addEditCitation</value>
+					</prop>
+					<prop oor:name="Title" oor:type="xs:string">
+						<value>Add/Edit Citation</value>
+					</prop>
+					<prop oor:name="Target" oor:type="xs:string">
+						<value>_self</value>
+					</prop>
+				</node>
+				<node oor:name="m3" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>service:org.zotero.integration.ooo.ZoteroOpenOfficeIntegration?addEditBibliography</value>
+					</prop>
+					<prop oor:name="Title" oor:type="xs:string">
+						<value>Add/Edit Bibliography</value>
+					</prop>
+					<prop oor:name="Target" oor:type="xs:string">
+						<value>_self</value>
+					</prop>
+				</node>
+				<node oor:name="m5" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>private:separator</value>
+					</prop>
+				</node>
+				<node oor:name="m6" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>service:org.zotero.integration.ooo.ZoteroOpenOfficeIntegration?refresh</value>
+					</prop>
+					<prop oor:name="Title" oor:type="xs:string">
+						<value>Refresh</value>
+					</prop>
+					<prop oor:name="Target" oor:type="xs:string">
+						<value>_self</value>
+					</prop>
+				</node>
+				<node oor:name="m7" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>service:org.zotero.integration.ooo.ZoteroOpenOfficeIntegration?setDocPrefs</value>
+					</prop>
+					<prop oor:name="Title" oor:type="xs:string">
+						<value>Set Document Preferences</value>
+					</prop>
+					<prop oor:name="Target" oor:type="xs:string">
+						<value>_self</value>
+					</prop>
+				</node>
+				<node oor:name="m8" oor:op="replace">
+					<prop oor:name="Context" oor:type="xs:string">
+						<value>com.sun.star.text.TextDocument, com.sun.star.text.GlobalDocument</value>
+					</prop>
+					<prop oor:name="URL" oor:type="xs:string">
+						<value>service:org.zotero.integration.ooo.ZoteroOpenOfficeIntegration?removeCodes</value>
+					</prop>
+					<prop oor:name="Title" oor:type="xs:string">
+						<value>Unlink Citations</value>
+					</prop>
+					<prop oor:name="Target" oor:type="xs:string">
+						<value>_self</value>
+					</prop>
+				</node>
+			</node>
+		</node>
 		<node oor:name="OfficeToolBar">
 			<node oor:name="Zotero.OfficeToolBar" oor:op="replace">
 				<prop oor:name="Title" oor:type="xs:string">


### PR DESCRIPTION
I recently tried to figure out how extensions can add themselves to the LibreOffice NotebookBar and stumbled across this project. I didn't ever use zotero or the LibreOffice extension, but you may want to use this commit to include the zotero toolbar in the LibreOffice "Extensions" Tab.

Sadly, icons are currently (LO 6.4) blurry, but this is also the case for normal toolbars.
Also, there seems to be no way to show icon+text as in other tabs.
Clearly, NotebookBar development is still ongoing.

should fix https://github.com/zotero/zotero-libreoffice-integration/issues/46